### PR TITLE
feat: remove thiserror dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,6 @@ dependencies = [
  "once_cell",
  "pomsky-syntax",
  "regex",
- "thiserror",
 ]
 
 [[package]]
@@ -581,7 +580,6 @@ dependencies = [
  "miette",
  "owo-colors",
  "pomsky",
- "thiserror",
 ]
 
 [[package]]
@@ -597,7 +595,6 @@ version = "0.7.0"
 dependencies = [
  "arbitrary",
  "strsim",
- "thiserror",
 ]
 
 [[package]]

--- a/pomsky-bin/Cargo.toml
+++ b/pomsky-bin/Cargo.toml
@@ -20,7 +20,6 @@ path = "src/main.rs"
 
 [dependencies]
 atty = "0.2.14"
-thiserror = "1.0.32"
 owo-colors = { version = "3.4.0", features = ["supports-colors"] }
 lexopt = "0.2.1"
 

--- a/pomsky-lib/Cargo.toml
+++ b/pomsky-lib/Cargo.toml
@@ -21,7 +21,6 @@ dbg = ["pomsky-syntax/dbg"]
 suggestions = ["pomsky-syntax/suggestions"]
 
 [dependencies]
-thiserror = "1.0.32"
 pomsky-syntax = { version = "0.7.0", path = "../pomsky-syntax" }
 arbitrary = { version = "1.1.3", features = ["derive"], optional = true }
 miette = { version = "5.3.0", features = ["fancy"], optional = true }

--- a/pomsky-lib/src/error/compile_error.rs
+++ b/pomsky-lib/src/error/compile_error.rs
@@ -34,7 +34,7 @@ impl std::error::Error for CompileError {}
 impl core::fmt::Display for CompileError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if let Some(std::ops::Range { start, end }) = self.span.range() {
-            write!(f, "{}\n  at {}..{}", self.kind, start, end)
+            write!(f, "{}\n  at {start}..{end}", self.kind)
         } else {
             self.kind.fmt(f)
         }
@@ -87,13 +87,12 @@ impl std::error::Error for CompileErrorKind {}
 impl core::fmt::Display for CompileErrorKind {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            CompileErrorKind::ParseError(kind) => write!(f, "Parse error: {}", kind),
+            CompileErrorKind::ParseError(kind) => write!(f, "Parse error: {kind}"),
             CompileErrorKind::Unsupported(feature, flavor) => {
                 write!(
                     f,
-                    "Compile error: Unsupported feature `{}` in the `{:?}` regex flavor",
+                    "Compile error: Unsupported feature `{}` in the `{flavor:?}` regex flavor",
                     feature.name(),
-                    flavor
                 )
             }
             CompileErrorKind::UnsupportedPomskySyntax(inner) => inner.fmt(f),
@@ -101,13 +100,13 @@ impl core::fmt::Display for CompileErrorKind {
                 write!(f, "Group references this large aren't supported")
             }
             CompileErrorKind::UnknownReferenceNumber(group) => {
-                write!(f, "Reference to unknown group. There is no group number {}", group)
+                write!(f, "Reference to unknown group. There is no group number {group}")
             }
             CompileErrorKind::UnknownReferenceName { found, .. } => {
-                write!(f, "Reference to unknown group. There is no group named `{}`", found)
+                write!(f, "Reference to unknown group. There is no group named `{found}`")
             }
             CompileErrorKind::NameUsedMultipleTimes(name) => {
-                write!(f, "Compile error: Group name `{}` used multiple times", name)
+                write!(f, "Compile error: Group name `{name}` used multiple times")
             }
             CompileErrorKind::EmptyClass => {
                 write!(f, "Compile error: This character class is empty")
@@ -122,15 +121,13 @@ impl core::fmt::Display for CompileErrorKind {
                 write!(f, "References within `let` statements are currently not supported")
             }
             CompileErrorKind::UnknownVariable { found, .. } => {
-                write!(f, "Variable `{}` doesn't exist", found)
+                write!(f, "Variable `{found}` doesn't exist")
             }
             CompileErrorKind::RecursiveVariable => write!(f, "Variables can't be used recursively"),
-            CompileErrorKind::RangeIsTooBig(digits) => write!(
-                f,
-                "Range is too big, it isn't allowed to contain more than {} digits",
-                digits
-            ),
-            CompileErrorKind::Other(error) => write!(f, "Compile error: {}", error),
+            CompileErrorKind::RangeIsTooBig(digits) => {
+                write!(f, "Range is too big, it isn't allowed to contain more than {digits} digits")
+            }
+            CompileErrorKind::Other(error) => write!(f, "Compile error: {error}"),
         }
     }
 }
@@ -216,9 +213,9 @@ impl std::error::Error for UnsupportedError {}
 impl core::fmt::Display for UnsupportedError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let error = match self {
-            UnsupportedError::Grapheme => "Grapheme is not supported",
-            UnsupportedError::NumberedGroups => "Numbered capturing groups is not supported",
-            UnsupportedError::NamedGroups => "Named capturing groups is not supported",
+            UnsupportedError::Grapheme => "Grapheme isn't supported",
+            UnsupportedError::NumberedGroups => "Numbered capturing groups aren't supported",
+            UnsupportedError::NamedGroups => "Named capturing groups aren't supported",
             UnsupportedError::References => "References aren't supported",
             UnsupportedError::LazyMode => "Lazy mode isn't supported",
             UnsupportedError::Ranges => "Ranges aren't supported",

--- a/pomsky-lib/src/error/diagnostics.rs
+++ b/pomsky-lib/src/error/diagnostics.rs
@@ -6,8 +6,7 @@ use pomsky_syntax::{
 
 use super::{compile_error::CompileErrorKind, CharClassError, CharStringError, CompileError};
 
-#[cfg_attr(feature = "miette", derive(Debug, thiserror::Error))]
-#[cfg_attr(feature = "miette", error("{}", .msg))]
+#[cfg_attr(feature = "miette", derive(Debug))]
 #[non_exhaustive]
 /// A struct containing detailed information about an error, which can be
 /// displayed beautifully with [miette](https://docs.rs/miette/latest/miette/).
@@ -25,6 +24,16 @@ pub struct Diagnostic {
     /// The start and end byte positions of the source code where the error
     /// occurred.
     pub span: Span,
+}
+
+#[cfg(feature = "miette")]
+impl std::error::Error for Diagnostic {}
+
+#[cfg(feature = "miette")]
+impl core::fmt::Display for Diagnostic {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.msg.fmt(f)
+    }
 }
 
 /// Indicates whether a diagnostic is an error or a warning

--- a/pomsky-syntax/Cargo.toml
+++ b/pomsky-syntax/Cargo.toml
@@ -20,7 +20,6 @@ dbg = []
 suggestions = ["strsim"]
 
 [dependencies]
-thiserror = "1.0.32"
 strsim = { version = "0.10.0", optional = true }
 
 [dependencies.arbitrary]

--- a/pomsky-syntax/src/error.rs
+++ b/pomsky-syntax/src/error.rs
@@ -19,7 +19,7 @@ pub struct ParseError {
 impl core::fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(std::ops::Range { start, end }) = self.span.range() {
-            write!(f, "{}\n  at {}..{}", self.kind, start, end)
+            write!(f, "{}\n  at {start}..{end}", self.kind)
         } else {
             self.kind.fmt(f)
         }
@@ -97,25 +97,25 @@ impl std::error::Error for ParseErrorKind {}
 impl core::fmt::Display for ParseErrorKind {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            ParseErrorKind::Multiple(_) => writeln!(f, "Multiple parsing errors encountered:"),
+            ParseErrorKind::Multiple(_) => writeln!(f, "Multiple parsing errors encountered"),
 
             ParseErrorKind::UnknownToken => write!(f, "Unknown token"),
             ParseErrorKind::LexErrorWithMessage(msg) => msg.fmt(f),
             ParseErrorKind::Dot => write!(f, "The dot is not supported"),
             ParseErrorKind::KeywordAfterLet(keyword) => {
-                write!(f, "Unexpected keyword `{}`", keyword)
+                write!(f, "Unexpected keyword `{keyword}`")
             }
             ParseErrorKind::UnexpectedKeyword(keyword) => {
-                write!(f, "Unexpected keyword `{}`", keyword)
+                write!(f, "Unexpected keyword `{keyword}`")
             }
 
             ParseErrorKind::Deprecated(deprecation) => deprecation.fmt(f),
 
-            ParseErrorKind::Expected(expected) => write!(f, "Expected {}", expected),
+            ParseErrorKind::Expected(expected) => write!(f, "Expected {expected}"),
             ParseErrorKind::LeftoverTokens => {
                 write!(f, "There are leftover tokens that couldn't be parsed")
             }
-            ParseErrorKind::ExpectedToken(token) => write!(f, "Expected {}", token),
+            ParseErrorKind::ExpectedToken(token) => write!(f, "Expected {token}"),
             ParseErrorKind::ExpectedCodePointOrChar => {
                 write!(f, "Expected code point or character")
             }
@@ -227,10 +227,10 @@ impl core::fmt::Display for CharClassError {
         match self {
             CharClassError::Empty => write!(f, "This character class is empty"),
             CharClassError::CaretInGroup => write!(f, "`^` is not a valid token"),
-            CharClassError::DescendingRange(a, b) => write!(
+            &CharClassError::DescendingRange(a, b) => write!(
                 f,
                 "Character range must be in increasing order, but it is U+{:04X?} - U+{:04X?}",
-                *a as u32, *b as u32
+                a as u32, b as u32
             ),
             CharClassError::Invalid => {
                 write!(f, "Expected string, range, code point or named character class")
@@ -239,10 +239,10 @@ impl core::fmt::Display for CharClassError {
                 write!(f, "This combination of character classes is not allowed")
             }
             CharClassError::UnknownNamedClass { found, .. } => {
-                write!(f, "Unknown character class `{}`", found)
+                write!(f, "Unknown character class `{found}`")
             }
             CharClassError::Negative => write!(f, "This character class can't be negated"),
-            CharClassError::Keyword(keyword) => write!(f, "Unexpected keyword `{}`", keyword),
+            CharClassError::Keyword(keyword) => write!(f, "Unexpected keyword `{keyword}`"),
         }
     }
 }

--- a/pomsky-syntax/src/lexer/error.rs
+++ b/pomsky-syntax/src/lexer/error.rs
@@ -1,55 +1,33 @@
 //! This module contains errors that can occur during lexing.
 
 /// An error message for a token that is invalid in a pomsky expression.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum LexErrorMsg {
-    #[error("This syntax is not supported")]
     GroupNonCapturing,
-    #[error("This syntax is not supported")]
     GroupLookahead,
-    #[error("This syntax is not supported")]
     GroupLookaheadNeg,
-    #[error("This syntax is not supported")]
     GroupLookbehind,
-    #[error("This syntax is not supported")]
     GroupLookbehindNeg,
-    #[error("This syntax is not supported")]
     GroupNamedCapture,
-    #[error("This syntax is not supported")]
     GroupPcreBackreference,
-    #[error("Comments have a different syntax")]
     GroupComment,
-    #[error("Atomic groups are not supported")]
     GroupAtomic,
-    #[error("Conditionals are not supported")]
     GroupConditional,
-    #[error("Branch reset groups are not supported")]
     GroupBranchReset,
-    #[error("Subroutines are not supported")]
     GroupSubroutineCall,
-    #[error("This syntax is not supported")]
     GroupOther,
 
-    #[error("Backslash escapes are not supported")]
     Backslash,
-    #[error("Backslash escapes are not supported")]
     BackslashU4,
-    #[error("Backslash escapes are not supported")]
     BackslashX2,
-    #[error("Backslash escapes are not supported")]
     BackslashUnicode,
-    #[error("Backslash escapes are not supported")]
     BackslashProperty,
-    #[error("Backslash escapes are not supported")]
     BackslashGK,
 
-    #[error("This string literal doesn't have a closing quote")]
     UnclosedString,
 
-    #[error("The `<%` literal is deprecated.")]
     DeprStart,
-    #[error("The `%>` literal is deprecated.")]
     DeprEnd,
 }
 
@@ -59,5 +37,41 @@ impl LexErrorMsg {
     /// The `slice` argument must be the same string that you tried to parse.
     pub fn get_help(&self, slice: &str) -> Option<String> {
         super::diagnostics::get_parse_error_msg_help(*self, slice)
+    }
+}
+
+impl std::error::Error for LexErrorMsg {}
+
+impl core::fmt::Display for LexErrorMsg {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let error = match self {
+            LexErrorMsg::GroupNonCapturing
+            | LexErrorMsg::GroupLookahead
+            | LexErrorMsg::GroupLookaheadNeg
+            | LexErrorMsg::GroupLookbehind
+            | LexErrorMsg::GroupLookbehindNeg
+            | LexErrorMsg::GroupNamedCapture
+            | LexErrorMsg::GroupPcreBackreference
+            | LexErrorMsg::GroupOther => "This syntax is not supported",
+            LexErrorMsg::GroupComment => "Comments have a different syntax",
+            LexErrorMsg::GroupAtomic => "Atomic groups are not supported",
+            LexErrorMsg::GroupConditional => "Conditionals are not supported",
+            LexErrorMsg::GroupBranchReset => "Branch reset groups are not supported",
+            LexErrorMsg::GroupSubroutineCall => "Subroutines are not supported",
+
+            LexErrorMsg::Backslash
+            | LexErrorMsg::BackslashU4
+            | LexErrorMsg::BackslashX2
+            | LexErrorMsg::BackslashUnicode
+            | LexErrorMsg::BackslashProperty
+            | LexErrorMsg::BackslashGK => "Backslash escapes are not supported",
+
+            LexErrorMsg::UnclosedString => "This string literal doesn't have a closing quote",
+
+            LexErrorMsg::DeprStart => "The `<%` literal is deprecated.",
+            LexErrorMsg::DeprEnd => "The `%>` literal is deprecated.",
+        };
+
+        f.write_str(error)
     }
 }


### PR DESCRIPTION
# Description

This PR removes the dependency on `thiserror`, which can be replaced by a manual implementation of `std::error::Error` and `core::fmt::Display`. This makes `pomsky` and `pomsky-macro` external dependency free! :tada:

I made these changes to avoid adding proc-macro dependencies to a small project where I used `pomsky-macro`. I used Copilot to copy most of error messages, they should be checked again to ensure I didn't changed anything.

~~Fixes # (issue)~~ No issue was created.

# Checklist:

- [x] My code is formatted with `cargo fmt`
- [x] My code compiles with the latest stable Rust toolchain
- [x] All tests pass with `cargo test`
- [x] My changes generate no new warnings with `cargo clippy`
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~My changes are covered by tests~~
